### PR TITLE
Safeguard against None values in serve_request_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ def _add_ray_serve_context(span: Span) -> None:
     span.set_attribute("ray.task_id", ray_context.get_task_id())
 
     # add request id
-    serve_request_context = ray.serve.context._serve_request_context.get()
+    serve_request_context = ray.serve.context._get_serve_request_context()
     span.set_attribute("ray.request_id", serve_request_context.request_id)
 
 

--- a/exporter_dd.py
+++ b/exporter_dd.py
@@ -15,7 +15,7 @@ def _add_ray_serve_context(span: Span) -> None:
     span.set_attribute("ray.task_id", ray_context.get_task_id())
 
     # add request id
-    serve_request_context = ray.serve.context._serve_request_context.get()
+    serve_request_context = ray.serve.context._get_serve_request_context()
     span.set_attribute("ray.request_id", serve_request_context.request_id)
 
 


### PR DESCRIPTION
As of `ray==2.43.0`, `ray.serve.context._serve_request_context.get()` can return a `None` value. This update ensures safeguards against these `None`s, relying on Ray to set a `RequestContext` if needed:

```
def _get_serve_request_context():
    """Get the current request context.

    Returns:
        The current request context
    """

    if _serve_request_context.get() is None:
        _serve_request_context.set(_RequestContext())
    return _serve_request_context.get()
```